### PR TITLE
Fix for maximum storage capacity

### DIFF
--- a/src/models/classes/container.js
+++ b/src/models/classes/container.js
@@ -12,6 +12,12 @@ class Container extends StorageCore
             throw new TypeError("Expected a Product, but got a " + product.constructor.name);
         }
 
+        var availableCapacity = this.capacity - this._usedCapacity();
+
+        if (availableCapacity < product.shelfSize()) {
+            throw new Error("There is no more capacity in this " + this.name + "; cannot add " + product.name);
+        }
+
         super.addItem(product);
     }
 

--- a/src/models/classes/core/storagecore.js
+++ b/src/models/classes/core/storagecore.js
@@ -20,9 +20,8 @@ class StorageCore {
     addItem(item)
     {
         var availableCapacity = this.capacity - this._usedCapacity();
-        var totalSize = item.quantity * item.size;
 
-        if (availableCapacity <= 0 || availableCapacity < totalSize) {
+        if (availableCapacity <= 0) {
             throw new Error("There is no more capacity in this " + this.name + "; cannot add " + item.name);
         }
 

--- a/src/models/classes/core/storagecore.js
+++ b/src/models/classes/core/storagecore.js
@@ -20,8 +20,9 @@ class StorageCore {
     addItem(item)
     {
         var availableCapacity = this.capacity - this._usedCapacity();
+        var totalSize = item.quantity * item.size;
 
-        if (availableCapacity <= 0) {
+        if (availableCapacity <= 0 || availableCapacity < totalSize) {
             throw new Error("There is no more capacity in this " + this.name + "; cannot add " + item.name);
         }
 


### PR DESCRIPTION
In the old code you were able to put more in a container than possible.
There was no check whether the order amount*size fitted in the space left in the container.