### PR TITLE
Fix purchasing trucks

### DIFF
--- a/src/controllers/factorycontroller.js
+++ b/src/controllers/factorycontroller.js
@@ -39,7 +39,7 @@ class FactoryController extends OrderController
 
         //adds an extra truck after cost validation
         $("#buy-truck").click(() => {
-            if (GAME.model.config.money > GAME.model.config.costExtraTruck) {
+            if (GAME.model.config.money >= GAME.model.config.costExtraTruck) {
                 MoneyController.updateMoney(-GAME.model.config.costExtraTruck);
                 GAME.model.config.maxSimultaneousOrders++;
 

--- a/src/controllers/factorycontroller.js
+++ b/src/controllers/factorycontroller.js
@@ -60,7 +60,7 @@ class FactoryController extends OrderController
             } else {
                 toastr.warning(Controller.l("You cannot afford to increase the size of your trucks!"))
             }
-            });
+        });
 
 
         // updates the information for the current order process


### PR DESCRIPTION
Currently not able to purchase a truck if you have 500 left.

You can test this yourself by buying only new trucks after you loaded the game.